### PR TITLE
Change master key password to byte[]

### DIFF
--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/reader/DefaultMasterKeyReader.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/reader/DefaultMasterKeyReader.java
@@ -36,6 +36,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -148,8 +150,13 @@ public class DefaultMasterKeyReader implements MasterKeyReader {
 
             for (MasterKey masterKey : masterKeys) {
                 logger.debug("Reading master key '{}' from file.", masterKey.getMasterKeyName());
-                Optional.ofNullable(properties.getProperty(masterKey.getMasterKeyName()))
-                        .ifPresent(s -> masterKey.setMasterKeyValue(s.toCharArray()));
+                byte[] masterKeyValue = (byte[]) Optional.ofNullable(
+                        properties.get(masterKey.getMasterKeyName()))
+                        .orElseThrow(() -> new SecureVaultException("Master Key value not found for : "
+                                + masterKey.getMasterKeyName()));
+                ByteBuffer byteBuffer = ByteBuffer.wrap(masterKeyValue);
+                CharBuffer charBuffer = StandardCharsets.UTF_8.decode(byteBuffer);
+                masterKey.setMasterKeyValue(charBuffer.array());
             }
 
             inputStream.close();

--- a/features/org.wso2.carbon.secvault.feature/resources/conf/master-keys.yaml
+++ b/features/org.wso2.carbon.secvault.feature/resources/conf/master-keys.yaml
@@ -1,4 +1,6 @@
 permanent: true
+# mastterKeys should be given in the base64 format and the data type of the
+# password should be explicitly specified as binary (type !!binary).
 masterKeys:
-  keyStorePassword: wso2carbon
-  privateKeyPassword: wso2carbon
+  keyStorePassword: !!binary d3NvMmNhcmJvbg==
+  privateKeyPassword: !!binary d3NvMmNhcmJvbg==

--- a/tools/org.wso2.carbon.secvault.ciphertool/src/test/java/org/wso2/carbon/secvault/ciphertool/utils/TestUtils.java
+++ b/tools/org.wso2.carbon.secvault.ciphertool/src/test/java/org/wso2/carbon/secvault/ciphertool/utils/TestUtils.java
@@ -78,8 +78,8 @@ public class TestUtils {
     public static void createDefaultMasterKeyFile(boolean isPermanent) throws SecureVaultException {
         MasterKeyConfiguration masterKeyConfiguration = new MasterKeyConfiguration();
         Properties properties = new Properties();
-        properties.setProperty("keyStorePassword", "wso2carbon");
-        properties.setProperty("privateKeyPassword", "wso2carbon");
+        properties.put("keyStorePassword", "wso2carbon".getBytes());
+        properties.put("privateKeyPassword", "wso2carbon".getBytes());
         ClassUtils.setToPrivateField(masterKeyConfiguration, "masterKeys", properties);
         ClassUtils.setToPrivateField(masterKeyConfiguration, "permanent", isPermanent);
 

--- a/tools/org.wso2.carbon.secvault.ciphertool/src/test/java/org/wso2/carbon/secvault/ciphertool/utils/TestUtils.java
+++ b/tools/org.wso2.carbon.secvault.ciphertool/src/test/java/org/wso2/carbon/secvault/ciphertool/utils/TestUtils.java
@@ -43,6 +43,7 @@ import java.util.Properties;
  * @since 5.0.0
  */
 public class TestUtils {
+    private static final String WSO2_CARBON_PASSWORD = "wso2carbon";
     /**
      * Create master key file
      *
@@ -78,8 +79,8 @@ public class TestUtils {
     public static void createDefaultMasterKeyFile(boolean isPermanent) throws SecureVaultException {
         MasterKeyConfiguration masterKeyConfiguration = new MasterKeyConfiguration();
         Properties properties = new Properties();
-        properties.put("keyStorePassword", "wso2carbon".getBytes());
-        properties.put("privateKeyPassword", "wso2carbon".getBytes());
+        properties.put("keyStorePassword", WSO2_CARBON_PASSWORD.getBytes());
+        properties.put("privateKeyPassword", WSO2_CARBON_PASSWORD.getBytes());
         ClassUtils.setToPrivateField(masterKeyConfiguration, "masterKeys", properties);
         ClassUtils.setToPrivateField(masterKeyConfiguration, "permanent", isPermanent);
 

--- a/tools/org.wso2.carbon.secvault.ciphertool/src/test/resources/securevault/conf/master-keys.yaml
+++ b/tools/org.wso2.carbon.secvault.ciphertool/src/test/resources/securevault/conf/master-keys.yaml
@@ -1,4 +1,6 @@
 permanent: true
+# mastterKeys should be given in the base64 format and the data type of the
+# password should be explicitly specified as binary (type !!binary).
 masterKeys:
-  keyStorePassword: wso2carbon
-  privateKeyPassword: wso2carbon
+  keyStorePassword: !!binary d3NvMmNhcmJvbg==
+  privateKeyPassword: !!binary d3NvMmNhcmJvbg==


### PR DESCRIPTION
Resolves https://github.com/wso2/carbon-secvault/issues/22

Master Key Passwords were kept as Strings in the Master Key Reader.
As this could cause security vulnerabilities it was changed to keep these
passwords as byte[]s.