### PR TITLE
Fix the SecureVault bundle activator exception handling issue

### DIFF
--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/internal/SecureVaultActivator.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/internal/SecureVaultActivator.java
@@ -39,14 +39,21 @@ public class SecureVaultActivator implements BundleActivator {
 
     @Override
     public void start(BundleContext bundleContext) throws Exception {
-        SecureVaultDataHolder.getInstance().setBundleContext(bundleContext);
-        logger.debug("Starting Secure Vault bundle");
-        logger.debug("Initializing Secure Vault config...");
-        Path secureVaultYAMLPath = Utils.getRuntimeConfigPath().resolve(Constants.DEPLOYMENT_CONFIG_YAML);
-        SecureVaultDataHolder.getInstance().setSecureVaultConfiguration(SecureVaultUtils.getSecureVaultConfig
-                (secureVaultYAMLPath).orElseThrow(() -> new SecureVaultException("Error occurred when obtaining " +
-                "secure vault configuration.")));
-        logger.debug("Secure vault config successfully initialized");
+        try {
+            SecureVaultDataHolder.getInstance().setBundleContext(bundleContext);
+            logger.debug("Starting Secure Vault bundle");
+            logger.debug("Initializing Secure Vault config...");
+            Path secureVaultYAMLPath = Utils.getRuntimeConfigPath().resolve(Constants.DEPLOYMENT_CONFIG_YAML);
+            SecureVaultDataHolder.getInstance().setSecureVaultConfiguration(SecureVaultUtils.getSecureVaultConfig
+                    (secureVaultYAMLPath).orElseThrow(() -> new SecureVaultException("Error occurred when obtaining " +
+                    "secure vault configuration.")));
+            logger.debug("Secure vault config successfully initialized");
+        } catch (Throwable throwable) {
+            logger.error("Error occurred when initializing secure vault " + throwable.getMessage(),
+                    throwable);
+            throw new SecureVaultException("Error occurred when initializing secure vault " + throwable.getMessage(),
+                    throwable);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Resolves issue in SecureVault bundle activator exception handling. The existing implementation throws the errors while initializing the component bubble up to OSGi framework, but the problem is carbon logging uses pax logging as logging framework and it's not supported for Eclipse Equinox logging framework. Hence this OSGi bundle exception not captured by the logging framework.

## Goals
> Fix the SecureVault bundle activator exception handling issue

## Approach
> Catch the Throwable and logging the exception with compatible logging framework and bubble-up the exception to OSGi framework.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A