### PR TITLE
Fix issue when creating secret resolver with new config system.

### DIFF
--- a/src/main/java/org/wso2/securevault/SecretResolverFactory.java
+++ b/src/main/java/org/wso2/securevault/SecretResolverFactory.java
@@ -196,6 +196,14 @@ public class SecretResolverFactory {
                 for (String token : tokens) {
                     secretResolver.addProtectedToken(token);
                 }
+            } else {
+                for (Map.Entry entry : properties.entrySet()) {
+                    String attributeValue = (String) entry.getValue();
+                    String protectedToken = MiscellaneousUtil.getProtectedToken(attributeValue);
+                    if (protectedToken != null && protectedToken.length() > 0) {
+                        secretResolver.addProtectedToken(protectedToken);
+                    }
+                }
             }
         }
         return secretResolver;


### PR DESCRIPTION
## Purpose
> When creating a `SecretResolver` using `create(Properties properties, String propertyPrefix)` method currently we do not consider the alias `"$secret"` which is needed for the new config system.

