### PR TITLE
Add support for optional configurations

### DIFF
--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultConstants.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultConstants.java
@@ -35,6 +35,18 @@ public class SecureVaultConstants {
     public static final String MASTER_KEYS_YAML_CONFIG_PROPERTY = "masterKeyReaderFile";
     public static final String SECRET_PROPERTIES_CONFIG_PROPERTY = "secretPropertiesFile";
 
+    public static final String DEFAULT_SECRET_REPOSITORY =
+                                                    "org.wso2.carbon.secvault.repository.DefaultSecretRepository";
+    public static final String DEFAULT_PRIVATE_KEY_ALIAS = "wso2carbon";
+    public static final String DEFAULT_KEYSTORE_LOCATION = "${sys:carbon.home}/resources/security/securevault.jks";
+    public static final String DEFAULT_SECRET_PROPERTIES_FILE =
+                                                    "${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties";
+
+    public static final String DEFAULT_MASTER_KEY_READER = "org.wso2.carbon.secvault.reader.DefaultMasterKeyReader";
+    public static final String DEFAULT_MASTER_KEY_READER_FILE =
+                                                    "${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml";
+
+
     /**
      * Remove default constructor and make it not available to initialize.
      */

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultUtils.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultUtils.java
@@ -20,6 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.secvault.exception.SecureVaultException;
 import org.wso2.carbon.secvault.internal.SecureVaultDataHolder;
+import org.wso2.carbon.secvault.model.MasterKeyReaderConfiguration;
+import org.wso2.carbon.secvault.model.SecretRepositoryConfiguration;
 import org.wso2.carbon.secvault.model.SecureVaultConfiguration;
 import org.wso2.carbon.utils.StringUtils;
 import org.yaml.snakeyaml.Yaml;
@@ -49,6 +51,17 @@ import java.util.Properties;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_KEYSTORE_LOCATION;
+import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_MASTER_KEY_READER;
+import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_MASTER_KEY_READER_FILE;
+import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_PRIVATE_KEY_ALIAS;
+import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_SECRET_PROPERTIES_FILE;
+import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_SECRET_REPOSITORY;
+import static org.wso2.carbon.secvault.SecureVaultConstants.MASTER_KEYS_YAML_CONFIG_PROPERTY;
+import static org.wso2.carbon.secvault.SecureVaultConstants.SECRET_PROPERTIES_CONFIG_PROPERTY;
+import static org.wso2.carbon.secvault.cipher.JKSBasedCipherProvider.ALIAS;
+import static org.wso2.carbon.secvault.cipher.JKSBasedCipherProvider.LOCATION;
 
 /**
  * Secure Vault utility methods.
@@ -86,12 +99,32 @@ public class SecureVaultUtils {
                     .toString());
         }
         String resolvedFileContent = SecureVaultUtils.resolveFileToString(secureVaultConfigPath);
-        Yaml yaml = new Yaml(new CustomClassLoaderConstructor(SecureVaultConfiguration.class,
-                SecureVaultConfiguration.class.getClassLoader()));
-        yaml.setBeanAccess(BeanAccess.FIELD);
-        SecureVaultConfiguration secureVaultConfiguration = yaml.loadAs(resolvedFileContent, SecureVaultConfiguration
-                .class);
-        logger.debug("Secure vault configurations loaded successfully.");
+        SecureVaultConfiguration secureVaultConfiguration;
+        if (!resolvedFileContent.isEmpty()) {
+            Yaml yaml = new Yaml(new CustomClassLoaderConstructor(SecureVaultConfiguration.class,
+                    SecureVaultConfiguration.class.getClassLoader()));
+            yaml.setBeanAccess(BeanAccess.FIELD);
+            secureVaultConfiguration = yaml.loadAs(resolvedFileContent, SecureVaultConfiguration.class);
+            logger.debug("Secure vault configurations loaded successfully.");
+        } else {
+
+            MasterKeyReaderConfiguration masterKeyReader = new MasterKeyReaderConfiguration();
+            masterKeyReader.setType(DEFAULT_MASTER_KEY_READER);
+            masterKeyReader.setParameter(MASTER_KEYS_YAML_CONFIG_PROPERTY,
+                    SecureVaultUtils.substituteVariables(DEFAULT_MASTER_KEY_READER_FILE));
+
+            SecretRepositoryConfiguration secretRepository = new SecretRepositoryConfiguration();
+            secretRepository.setType(DEFAULT_SECRET_REPOSITORY);
+            secretRepository.setParameter(ALIAS, DEFAULT_PRIVATE_KEY_ALIAS);
+            secretRepository.setParameter(LOCATION, SecureVaultUtils.substituteVariables(DEFAULT_KEYSTORE_LOCATION));
+            secretRepository.setParameter(SECRET_PROPERTIES_CONFIG_PROPERTY,
+                    SecureVaultUtils.substituteVariables(DEFAULT_SECRET_PROPERTIES_FILE));
+
+            secureVaultConfiguration = new SecureVaultConfiguration();
+            secureVaultConfiguration.setMasterKeyReader(masterKeyReader);
+            secureVaultConfiguration.setSecretRepository(secretRepository);
+        }
+
         return Optional.ofNullable(secureVaultConfiguration);
     }
 
@@ -242,7 +275,8 @@ public class SecureVaultUtils {
 
         if (configurationMap == null || configurationMap.isEmpty() ||
                 configurationMap.get(SecureVaultConstants.SECUREVAULT_NAMESPACE) == null) {
-            throw new SecureVaultException("Error initializing securevault, secure configuration does not exist");
+            logger.debug("Secure vault configuration no found returning empty string.");
+            return "";
         }
         return yaml.dumpAsMap(configurationMap.get(SecureVaultConstants.SECUREVAULT_NAMESPACE));
     }

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultUtils.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultUtils.java
@@ -275,8 +275,12 @@ public class SecureVaultUtils {
 
         if (configurationMap == null || configurationMap.isEmpty() ||
                 configurationMap.get(SecureVaultConstants.SECUREVAULT_NAMESPACE) == null) {
-            logger.debug("Secure vault configuration no found returning empty string.");
-            return "";
+            if (SecureVaultUtils.isOSGIEnv()) {
+                logger.debug("Secure vault configuration not found in OSGi mode, returning null.");
+                return "";
+            } else {
+                throw new SecureVaultException("Error initializing securevault, secure configuration does not exist");
+            }
         }
         return yaml.dumpAsMap(configurationMap.get(SecureVaultConstants.SECUREVAULT_NAMESPACE));
     }

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/cipher/JKSBasedCipherProvider.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/cipher/JKSBasedCipherProvider.java
@@ -52,8 +52,8 @@ import javax.crypto.NoSuchPaddingException;
  */
 public class JKSBasedCipherProvider {
     private static Logger logger = LoggerFactory.getLogger(JKSBasedCipherProvider.class);
-    private static final String LOCATION = "keystoreLocation";
-    private static final String ALIAS = "privateKeyAlias";
+    public static final String LOCATION = "keystoreLocation";
+    public static final String ALIAS = "privateKeyAlias";
     public static final String KEY_STORE_PASSWORD = "keyStorePassword";
     public static final String PRIVATE_KEY_PASSWORD = "privateKeyPassword";
     private static final String JKS = "JKS";

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/model/MasterKeyReaderConfiguration.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/model/MasterKeyReaderConfiguration.java
@@ -40,6 +40,15 @@ public class MasterKeyReaderConfiguration {
     }
 
     /**
+     * Set master key reader implementation type.
+     *
+     * @param type master key reader implementation type
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
      * Get master key reader configuration parameters.
      *
      * @param key parameter key

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/model/SecretRepositoryConfiguration.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/model/SecretRepositoryConfiguration.java
@@ -40,6 +40,15 @@ public class SecretRepositoryConfiguration {
     }
 
     /**
+     * Set secret repository implementation type.
+     *
+     * @param type secret repository implementation type
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
      * Get secret repository configuration parameters.
      *
      * @param key parameter key

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/model/SecureVaultConfiguration.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/model/SecureVaultConfiguration.java
@@ -42,4 +42,12 @@ public class SecureVaultConfiguration {
     public MasterKeyReaderConfiguration getMasterKeyReaderConfig() {
         return masterKeyReader;
     }
+
+    public void setSecretRepository(SecretRepositoryConfiguration secretRepository) {
+        this.secretRepository = secretRepository;
+    }
+
+    public void setMasterKeyReader(MasterKeyReaderConfiguration masterKeyReader) {
+        this.masterKeyReader = masterKeyReader;
+    }
 }


### PR DESCRIPTION
## Purpose
$subject **ONLY on OSGi mode**
Default configurations will be as follows,

```
wso2.securevault:
  secretRepository:
    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
    parameters:
      privateKeyAlias: wso2carbon
      keystoreLocation: ${sys:carbon.home}/resources/security/securevault.jks
      secretPropertiesFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/secrets.properties
  masterKeyReader:
    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
    parameters:
      masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
```

## Goals
To make secure vault configuration optional

## Approach
The above configuration element is created by default if no configuration for wso2.securevault namespace is present in the deployment.yam file.

## User stories
N/A

## Release note
Secure vault configuration is optional

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests Pass All
 - Integration tests Passes All

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0_191
 
## Learning
N/A