### PR TITLE
Change secure vault namespace as 'securevault'

### DIFF
--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultConstants.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultConstants.java
@@ -30,6 +30,7 @@ public class SecureVaultConstants {
     public static final String PLAIN_TEXT = "plainText";
     public static final String SPACE = " ";
     public static final String SECUREVAULT_NAMESPACE = "wso2.securevault";
+    public static final String STREAMLINED_SECUREVAULT_NAMESPACE = "securevault";
 
     // System and environment variables
     public static final String MASTER_KEYS_YAML_CONFIG_PROPERTY = "masterKeyReaderFile";

--- a/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultUtils.java
+++ b/components/org.wso2.carbon.secvault/src/main/java/org/wso2/carbon/secvault/SecureVaultUtils.java
@@ -60,6 +60,8 @@ import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_SECRET_PROPE
 import static org.wso2.carbon.secvault.SecureVaultConstants.DEFAULT_SECRET_REPOSITORY;
 import static org.wso2.carbon.secvault.SecureVaultConstants.MASTER_KEYS_YAML_CONFIG_PROPERTY;
 import static org.wso2.carbon.secvault.SecureVaultConstants.SECRET_PROPERTIES_CONFIG_PROPERTY;
+import static org.wso2.carbon.secvault.SecureVaultConstants.SECUREVAULT_NAMESPACE;
+import static org.wso2.carbon.secvault.SecureVaultConstants.STREAMLINED_SECUREVAULT_NAMESPACE;
 import static org.wso2.carbon.secvault.cipher.JKSBasedCipherProvider.ALIAS;
 import static org.wso2.carbon.secvault.cipher.JKSBasedCipherProvider.LOCATION;
 
@@ -274,7 +276,8 @@ public class SecureVaultUtils {
         Map<String, Object> configurationMap = (Map<String, Object>) yaml.loadAs(configFileContent, Map.class);
 
         if (configurationMap == null || configurationMap.isEmpty() ||
-                configurationMap.get(SecureVaultConstants.SECUREVAULT_NAMESPACE) == null) {
+                (configurationMap.get(STREAMLINED_SECUREVAULT_NAMESPACE) == null &&
+                                                        configurationMap.get(SECUREVAULT_NAMESPACE) == null)) {
             if (SecureVaultUtils.isOSGIEnv()) {
                 logger.debug("Secure vault configuration not found in OSGi mode, returning null.");
                 return "";
@@ -282,7 +285,11 @@ public class SecureVaultUtils {
                 throw new SecureVaultException("Error initializing securevault, secure configuration does not exist");
             }
         }
-        return yaml.dumpAsMap(configurationMap.get(SecureVaultConstants.SECUREVAULT_NAMESPACE));
+
+        if (configurationMap.get(STREAMLINED_SECUREVAULT_NAMESPACE) != null) {
+            return yaml.dumpAsMap(configurationMap.get(STREAMLINED_SECUREVAULT_NAMESPACE));
+        }
+        return yaml.dumpAsMap(configurationMap.get(SECUREVAULT_NAMESPACE));
     }
 
     /**

--- a/components/org.wso2.carbon.secvault/src/test/java/org/wso2/carbon/secvault/SecureVaultStreamlinedConfigurationProviderTest.java
+++ b/components/org.wso2.carbon.secvault/src/test/java/org/wso2/carbon/secvault/SecureVaultStreamlinedConfigurationProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.secvault;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.wso2.carbon.secvault.exception.SecureVaultException;
+import org.wso2.carbon.secvault.internal.SecureVaultDataHolder;
+import org.wso2.carbon.secvault.utils.TestUtils;
+
+import java.nio.file.Path;
+
+/**
+ * Unit tests class for SecureVault Configuration.
+ *
+ * @since 5.0.0
+ */
+public class SecureVaultStreamlinedConfigurationProviderTest extends SecureVaultConfigurationProviderTest {
+
+    @BeforeTest
+    public void setup() {
+        try {
+            // master-keys.yaml file may not be available when running tests in IDE
+            // master-keys.yaml file is required to initialise secure vault
+            TestUtils.createDefaultMasterKeyFile(true);
+            Path secureVaultYAMLPath = TestUtils.getResourcePath("securevault", "conf", "secure-vault-2.yaml")
+                    .orElseThrow(() -> new SecureVaultException("Secure vault YAML path not found"));
+            SecureVaultDataHolder.getInstance().setSecureVaultConfiguration(SecureVaultUtils.getSecureVaultConfig
+                    (secureVaultYAMLPath).orElseThrow(() -> new SecureVaultException("Error occurred when obtaining " +
+                    "secure vault configuration.")));
+            new SecureVaultFactory().getSecureVault(secureVaultYAMLPath)
+                    .orElseThrow(() -> new SecureVaultException("Error occurred when getting secure vault instance"));
+        } catch (SecureVaultException e) {
+            Assert.fail();
+        }
+    }
+}

--- a/components/org.wso2.carbon.secvault/src/test/resources/securevault/conf/secure-vault-2.yaml
+++ b/components/org.wso2.carbon.secvault/src/test/resources/securevault/conf/secure-vault-2.yaml
@@ -1,0 +1,11 @@
+securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: src/test/resources/resources/security/securevault.jks
+      secretPropertiesFile: src/test/resources/securevault/conf/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: src/test/resources/securevault/conf/master-keys.yaml


### PR DESCRIPTION
## Purpose
$subject 
```
securevault:
   secretRepository:
     type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
     parameters:
       privateKeyAlias: wso2carbon
       keystoreLocation: resources/security/securevault.jks
       secretPropertiesFile: conf/secrets.properties
   masterKeyReader:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
       masterKeyReaderFile: conf/master-keys.yaml
```

## Goals
Streamline configurations as discussed in https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8
 
## Approach
'securevault' is used when parsing YAML file first then falls back to wso2.securevault

## User stories
N/A

## Release note
N/A

## Documentation
N/A as it is backward compatible

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests - Attached Herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDJ 1.8.0_191
 
## Learning
N/A