### PR TITLE
Creating the Core Support for external Vault Support for Carbon Configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,12 @@
             <version>6.11</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -176,6 +181,7 @@
         <commons_io.version>2.0</commons_io.version>
         <commons-codec.version>1.2</commons-codec.version>
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <powermock.version>1.7.1</powermock.version>
     </properties>
     <pluginRepositories>
 	<pluginRepository> 

--- a/src/main/java/org/wso2/securevault/commons/MiscellaneousUtil.java
+++ b/src/main/java/org/wso2/securevault/commons/MiscellaneousUtil.java
@@ -277,6 +277,26 @@ public class MiscellaneousUtil {
         return resolve(value, secretResolver);
     }
 
+    /**
+     * Validate the property value to avoid the processing of null values.
+     *
+     * @param propValue Value of the required property.
+     * @return Return true if not null.
+     */
+    public static boolean isValidPropertyValue(String propValue) {
+
+        if (propValue == null || "".equals(propValue)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Invalid property. Could not find a value as: " + propValue);
+            }
+            return false;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully retrieved value from secret-conf.properties: " + propValue);
+        }
+        return true;
+    }
+
     static List<ProtectedToken> extractProtectedTokens(String text) {
 
         List<ProtectedToken> tokenList = new ArrayList<>();

--- a/src/main/java/org/wso2/securevault/secret/SecretManager.java
+++ b/src/main/java/org/wso2/securevault/secret/SecretManager.java
@@ -1,5 +1,20 @@
 /**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
  *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 package org.wso2.securevault.secret;
 
@@ -13,6 +28,9 @@ import org.wso2.securevault.definition.TrustKeyStoreInformation;
 import org.wso2.securevault.keystore.IdentityKeyStoreWrapper;
 import org.wso2.securevault.keystore.TrustKeyStoreWrapper;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -35,17 +53,30 @@ public class SecretManager {
     private final static String PROP_PROVIDER = "provider";
     /* Dot string */
     private final static String DOT = ".";
+    // Property key for secretProviders stored in the secret-conf.properties file.
+    private final static String PROP_SECRET_PROVIDERS = "secretProviders";
+    // Delimiter string.
+    private final static String DELIMITER = ":";
 
     /*Root Secret Repository */
     private SecretRepository parentRepository;
     /* True , if secret manage has been started up properly- need to have a at
     least one Secret Repository*/
     private boolean initialized = false;
+    // True if the property secretRepositories configured in the secret-conf.properties file.
+    private boolean legacyProvidersExist = false;
+    // True if the property secretProviders configured in the secret-conf.properties file.
+    private boolean novelProvidersExist = false;
 
     // global password provider implementation class if defined in secret manager conf file
     private String globalSecretProvider =null;
     // property key for global secret provider
     private final static String PROP_SECRET_PROVIDER="carbon.secretProvider";
+
+    // To keep the providers listed under secretRepositories and secretProviders property located in the secret-conf.properties file.
+    private Map<String, String> providers = new HashMap<>();
+    // To keep the secret repositories coming from a provider listed under secretProviders property.
+    private Map<String, SecretRepository> secretRepositories = new HashMap<>();
 
     public static SecretManager getInstance() {
         return SECRET_MANAGER;
@@ -100,71 +131,49 @@ public class SecretManager {
             }
         }
 
-        String repositoriesString = MiscellaneousUtil.getProperty(
-                configurationProperties, PROP_SECRET_REPOSITORIES, null);
-        if (repositoriesString == null || "".equals(repositoriesString)) {
-            if (log.isDebugEnabled()) {
-                log.debug("No secret repositories have been configured");
-            }
-            return;
-        }
+        loadProviders(configurationProperties);
 
-        String[] repositories = repositoriesString.split(",");
-        if (repositories == null || repositories.length == 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("No secret repositories have been configured");
-            }
-            return;
-        }
-
-
-        //Create a KeyStore Information  for private key entry KeyStore
-        IdentityKeyStoreInformation identityInformation =
-                KeyStoreInformationFactory.createIdentityKeyStoreInformation(properties);
-
-        // Create a KeyStore Information for trusted certificate KeyStore
-        TrustKeyStoreInformation trustInformation =
-                KeyStoreInformationFactory.createTrustKeyStoreInformation(properties);
-
-        String identityKeyPass = null;
-        String identityStorePass = null;
-        String trustStorePass = null;
-        if(identityInformation != null){
-            identityKeyPass = identityInformation
-                    .getKeyPasswordProvider().getResolvedSecret();
-            identityStorePass = identityInformation
-                    .getKeyStorePasswordProvider().getResolvedSecret();
-        }
-
-        if(trustInformation != null){
-            trustStorePass = trustInformation
-                .getKeyStorePasswordProvider().getResolvedSecret();
-        }
-
-
-        if (!validatePasswords(identityStorePass, identityKeyPass, trustStorePass)) {
-            if (log.isDebugEnabled()) {
-                log.info("Either Identity or Trust keystore password is mandatory" +
-                        " in order to initialized secret manager.");
-            }
+        if (!isSecureVaultStatusValid()) {
             return;
         }
 
         IdentityKeyStoreWrapper identityKeyStoreWrapper = new IdentityKeyStoreWrapper();
-        identityKeyStoreWrapper.init(identityInformation, identityKeyPass);
-
         TrustKeyStoreWrapper trustKeyStoreWrapper = new TrustKeyStoreWrapper();
-        if(trustInformation != null){
-            trustKeyStoreWrapper.init(trustInformation);            
+        if (legacyProvidersExist) {
+            //Create a KeyStore Information  for private key entry KeyStore.
+            IdentityKeyStoreInformation identityInformation =
+                    KeyStoreInformationFactory.createIdentityKeyStoreInformation(properties);
+
+            // Create a KeyStore Information for trusted certificate KeyStore.
+            TrustKeyStoreInformation trustInformation =
+                    KeyStoreInformationFactory.createTrustKeyStoreInformation(properties);
+
+            String identityKeyPass = createIdentityKeyPassword(identityInformation);
+            String identityStorePass = createIdentityStorePassword(identityInformation);
+            String trustStorePass = createTrustStorePassword(trustInformation);
+
+            if (!validatePasswords(identityStorePass, identityKeyPass, trustStorePass)) {
+                if (log.isDebugEnabled()) {
+                    log.info(
+                            "Either Identity or Trust keystore password is mandatory in order to initialized secret manager.");
+                }
+                return;
+            }
+            identityKeyStoreWrapper.init(identityInformation, identityKeyPass);
+
+            if(trustInformation != null){
+                trustKeyStoreWrapper.init(trustInformation);
+            }
         }
-
         SecretRepository currentParent = null;
-        for (String secretRepo : repositories) {
+        for (Map.Entry repositoryProvider : providers.entrySet()) {
+            String providerType = (String) repositoryProvider.getKey();    //file,vault,hsm etc.
+            String propertyName = (String) repositoryProvider.getValue();  //secretRepositories or secretProviders only.
 
-            StringBuffer sb = new StringBuffer();
-            sb.append(PROP_SECRET_REPOSITORIES);
+            StringBuilder sb = new StringBuilder();
+            sb.append(propertyName);
             sb.append(DOT);
-            sb.append(secretRepo);
+            sb.append(providerType);
             String id = sb.toString();
             sb.append(DOT);
             sb.append(PROP_PROVIDER);
@@ -176,7 +185,7 @@ public class SecretManager {
             }
 
             if (log.isDebugEnabled()) {
-                log.debug("Initiating a File Based Secret Repository");
+                log.debug("Initiating a Secret Repository");
             }
 
             try {
@@ -185,14 +194,22 @@ public class SecretManager {
                 Object instance = aClass.newInstance();
 
                 if (instance instanceof SecretRepositoryProvider) {
-                    SecretRepository secretRepository = ((SecretRepositoryProvider) instance).
-                            getSecretRepository(identityKeyStoreWrapper, trustKeyStoreWrapper);
-                    secretRepository.init(configurationProperties, id);
-                    if (parentRepository == null) {
-                        parentRepository = secretRepository;
+                    if (PROP_SECRET_PROVIDERS.equals(propertyName)) {
+                        Properties filteredConfigs = filterConfigurations(providerType, configurationProperties);
+                        Map<String, SecretRepository> providerBasedSecretRepositories =
+                                ((SecretRepositoryProvider) instance).initProvider(filteredConfigs, providerType);
+                        secretRepositories.putAll(providerBasedSecretRepositories);
+                    } else if (PROP_SECRET_REPOSITORIES.equals(propertyName)){
+                        // This will be executed if and only if there`s a legacy secret provider configured.
+                        SecretRepository secretRepository = ((SecretRepositoryProvider) instance).
+                                getSecretRepository(identityKeyStoreWrapper, trustKeyStoreWrapper);
+                        secretRepository.init(configurationProperties, id);
+                        if (parentRepository == null) {
+                            parentRepository = secretRepository;
+                        }
+                        secretRepository.setParent(currentParent);
+                        currentParent = secretRepository;
                     }
-                    secretRepository.setParent(currentParent);
-                    currentParent = secretRepository;
                     if (log.isDebugEnabled()) {
                         log.debug("Successfully Initiate a Secret Repository provided by : "
                                 + provider);
@@ -215,6 +232,75 @@ public class SecretManager {
     }
 
     /**
+     * Split the secret annotation from the delimiter provided and decides whether to use the legacy provider
+     * or a novel provider to obtain the secret value of the requested alias.
+     *
+     * @param secretAnnotation String contains the alias, the provider type and the repository type.
+     * @return Plain text value of the required secret.
+     */
+    public String resolveSecret(String secretAnnotation) {
+
+        String[] secretAnnotationStrings = secretAnnotation.split(DELIMITER);
+        if (secretAnnotationStrings.length == 1) {
+            if (legacyProvidersExist) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Getting the value of " + secretAnnotation + " from the configured legacy provider.");
+                }
+                return getSecret(secretAnnotation);
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Getting the value of " + secretAnnotation + " from the providers listed under secretProviders property.");
+        }
+        return resolveSecret(secretAnnotationStrings);
+    }
+
+    /**
+     * Resolve the secret annotation for the secrets coming from repositories belongs to providers listed under
+     * secretProviders property.
+     * Repositories categorized under providers other than legacy providers will be identified based on the secret
+     * annotation. Under that, When there is only a single repository, provider type and the repository type should
+     * be assigned otherwise, annotation itself is going to be used to get the above-said values.
+     *
+     * @param annotation Value retrieve by the resolveSecret as the value to be resolved.
+     * @return If there is a secret , otherwise , alias itself.
+     */
+    private String resolveSecret(String[] annotation) throws SecureVaultException {
+
+        int length = annotation.length;
+
+        switch (length) {
+            case 1:
+                // When there is only one secret provider and repository configured.
+                if (providers.isEmpty()) {
+                    log.error("No provider has been configured. Returning the annotation itself.");
+                    return Arrays.toString(annotation);
+                }
+                if (secretRepositories.isEmpty()) {
+                    log.error("No repository has been configured. Returning the annotation itself.");
+                    return Arrays.toString(annotation);
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Set the values for the provider and the repository type. Returning the value for secret annotation.");
+                }
+                return getSecret((String) providers.keySet().toArray()[0],
+                        (String) secretRepositories.keySet().toArray()[0],
+                        annotation[0]);
+            case 3:
+                // When there are multiple secret providers and secret repositories configured.
+                if (log.isDebugEnabled()) {
+                    log.debug("Returning the value for secret annotation.");
+                }
+                // annotation[0] -> provider type, annotation[1] -> repository type, annotation[2] ->alias.
+                return getSecret(annotation[0], annotation[1], annotation[2]);
+            default:
+                throw new SecureVaultException("Invalid Annotation, The annotation expected to have " +
+                        "[provider_type , repository_type , alias] but got " + Arrays.toString(annotation));
+        }
+    }
+
+    /**
      * Returns the secret corresponding to the given alias name
      *
      * @param alias The logical or alias name
@@ -228,6 +314,30 @@ public class SecretManager {
             return alias;
         }
         return parentRepository.getSecret(alias);
+    }
+
+    /**
+     * Returns the encrypted value corresponding to the given secretAnnotation name where the
+     * secretAnnotation consists of provider type, repository type and the alias.
+     *
+     * @param provider   Provider type.
+     * @param repository Repository type.
+     * @param alias      Alias to be resolved.
+     * @return If there is a secret , otherwise , alias itself.
+     */
+    private String getSecret(String provider, String repository, String alias) {
+
+        if (!providers.containsKey(provider)) {
+            log.error(
+                    "Provider type in the annotation does not match with the configured providers. Returning the alias itself.");
+            return alias;
+        }
+        if (!secretRepositories.containsKey(repository)) {
+            log.error(
+                    "Repository type in the annotation does not match with the configured repositories Returning the alias itself.");
+            return alias;
+        }
+        return secretRepositories.get(repository).getSecret(alias);
     }
 
     /**
@@ -284,4 +394,185 @@ public class SecretManager {
     public String getGlobalSecretProvider() {
         return globalSecretProvider;
     }
+
+    /**
+     * Get all the provider listed under both secretRepositories and secretProviders properties.
+     *
+     * @param secretConfigurationProperties All the configuration properties.
+     */
+    private void loadProviders(Properties secretConfigurationProperties) {
+
+        readLegacyProviders(secretConfigurationProperties);
+        readNovelProviders(secretConfigurationProperties);
+    }
+
+    /**
+     * Read the providers listed under secretRepositories property.
+     *
+     * @param secretConfigurationProperties All the configuration properties.
+     */
+    private void readLegacyProviders(Properties secretConfigurationProperties) {
+
+        String legacyProvidersString =
+                MiscellaneousUtil.getProperty(secretConfigurationProperties, PROP_SECRET_REPOSITORIES, null);
+
+        // Checking whether the property value is null or not.
+        if (MiscellaneousUtil.isValidPropertyValue(legacyProvidersString)) {
+            legacyProvidersExist = true;
+            String[] legacyProviders = populateArrayOfSecretProviders(legacyProvidersString);
+            addToProvidersMap(legacyProviders, PROP_SECRET_REPOSITORIES);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Identified the providers listed under secretRepositories property of the secret-conf.");
+            }
+        }
+    }
+
+    /**
+     * Read the providers listed under secretProviders property.
+     *
+     * @param secretConfigurationProperties All the configuration properties.
+     */
+    private void readNovelProviders(Properties secretConfigurationProperties) {
+
+        String novelProvidersString =
+                MiscellaneousUtil.getProperty(secretConfigurationProperties, PROP_SECRET_PROVIDERS, null);
+
+        // Checking whether the property value is null or not.
+        if (MiscellaneousUtil.isValidPropertyValue(novelProvidersString)) {
+            novelProvidersExist = true;
+            String[] novelProviders = populateArrayOfSecretProviders(novelProvidersString);
+            addToProvidersMap(novelProviders, PROP_SECRET_PROVIDERS);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Identified the providers listed under secretProviders property of the secret-conf.");
+            }
+        }
+    }
+
+    /**
+     * Terminates if either properties, secretRepositories or secretProviders haven`t been configured.
+     */
+    private boolean isSecureVaultStatusValid() {
+
+        if (!(legacyProvidersExist || novelProvidersExist)) {
+            if (log.isDebugEnabled()) {
+                log.debug("No secret provider has been configured.");
+            }
+            return false;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Validated the secure vault status by identifying the configured secret providers.");
+        }
+        return true;
+    }
+
+    /**
+     * Util method to add all the providers from providers array to providers hash map along with the
+     * type (secretRepositories or secretProviders).
+     *
+     * @param providersArray Repositories array and secretProviders array generated from the properties,
+     *                       secretRepositories or secretProviders.
+     * @param providerType   SecretRepositories or secretProviders.
+     */
+    private void addToProvidersMap(String[] providersArray, String providerType) {
+
+        for (String providerName : providersArray) {
+            if (log.isDebugEnabled()) {
+                log.debug("Added a secret provider to providers map: " + providers);
+            }
+            providers.put(providerName, providerType);
+        }
+    }
+
+    /**
+     * Util method to add the split string of properties, secretRepositories or secretProviders to the Array.
+     *
+     * @param propertyValue Value of the property in the secret configuration file.
+     * @return An array containing the string.
+     */
+    private String[] populateArrayOfSecretProviders(String propertyValue) {
+
+        String[] propertyValues = propertyValue.split(",");
+        if (propertyValues.length == 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("No secret repositories have been configured.");
+            }
+        }
+        return propertyValues;
+    }
+
+    /**
+     * Create the identity key password.
+     *
+     * @param identityInformation KeyStore Information for private key entry KeyStore.
+     * @return IdentityKeyPassword.
+     */
+    private String createIdentityKeyPassword(IdentityKeyStoreInformation identityInformation) {
+
+        String identityKeyPass = null;
+
+        if (identityInformation != null) {
+            identityKeyPass = identityInformation
+                    .getKeyPasswordProvider().getResolvedSecret();
+        }
+        return identityKeyPass;
+    }
+
+    /**
+     * Create the identity store password.
+     *
+     * @param identityInformation KeyStore Information for private key entry KeyStore.
+     * @return IdentityStorePassword.
+     */
+    private String createIdentityStorePassword(IdentityKeyStoreInformation identityInformation) {
+
+        String identityStorePass = null;
+
+        if (identityInformation != null) {
+            identityStorePass = identityInformation
+                    .getKeyStorePasswordProvider().getResolvedSecret();
+        }
+        return identityStorePass;
+    }
+
+    /**
+     * Create the trust store password.
+     *
+     * @param trustInformation KeyStore Information for trusted certificate KeyStore.
+     * @return TrustStorePassword.
+     */
+    private String createTrustStorePassword(TrustKeyStoreInformation trustInformation) {
+
+        String trustStorePass = null;
+
+        if (trustInformation != null) {
+            trustStorePass = trustInformation
+                    .getKeyStorePasswordProvider().getResolvedSecret();
+        }
+        return trustStorePass;
+    }
+
+    /**
+     * Util method to get the properties for a given provider.
+     *
+     * @param provider         Provider type.
+     * @param configProperties All the configuration properties.
+     * @return Filtered set of properties for a given provider.
+     */
+    private Properties filterConfigurations(String provider, Properties configProperties) {
+
+        Properties filteredProps = new Properties();
+
+        configProperties.forEach((propKey, propValue) -> {
+            if (propKey.toString().contains(provider)) {
+                filteredProps.put(propKey, propValue);
+            }
+        });
+        if (log.isDebugEnabled()) {
+            log.debug("Returning the filtered properties.");
+        }
+        return filteredProps;
+    }
 }
+

--- a/src/main/java/org/wso2/securevault/secret/SecretRepositoryProvider.java
+++ b/src/main/java/org/wso2/securevault/secret/SecretRepositoryProvider.java
@@ -21,6 +21,9 @@ package org.wso2.securevault.secret;
 import org.wso2.securevault.keystore.IdentityKeyStoreWrapper;
 import org.wso2.securevault.keystore.TrustKeyStoreWrapper;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Factory method for creating a instance of a SecretRepository
@@ -35,4 +38,16 @@ public interface SecretRepositoryProvider {
      * @return A SecretRepository implementation
      */
     public SecretRepository getSecretRepository(IdentityKeyStoreWrapper identity, TrustKeyStoreWrapper trust);
+
+    /**
+     * Returns a List of initialized SecretRepositories.
+     *
+     * @param configurationProperties Properties from secret configurations file.
+     * @param providerType            Provider type.
+     * @return A collection of initialized SecretRepositories.
+     */
+    default Map<String, SecretRepository> initProvider(Properties configurationProperties, String providerType) {
+
+        return Collections.emptyMap();
+    }
 }

--- a/src/main/java/org/wso2/securevault/secret/handler/SecretManagerSecretCallbackHandler.java
+++ b/src/main/java/org/wso2/securevault/secret/handler/SecretManagerSecretCallbackHandler.java
@@ -41,7 +41,12 @@ public class SecretManagerSecretCallbackHandler extends AbstractSecretCallbackHa
 
         String id = singleSecretCallback.getId();
         if (id != null && !"".equals(id)) {
-            singleSecretCallback.setSecret(secretManager.getSecret(id));
+            if (log.isDebugEnabled()) {
+                log.debug("The secret annotation provided is: " + id);
+            }
+            singleSecretCallback.setSecret(secretManager.resolveSecret(id));
+        } else {
+            log.error("The provided Secret Annotation is empty.");
         }
     }
 }

--- a/src/main/java/org/wso2/securevault/secret/repository/VaultSecretRepositoryProvider.java
+++ b/src/main/java/org/wso2/securevault/secret/repository/VaultSecretRepositoryProvider.java
@@ -1,0 +1,152 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.securevault.secret.repository;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.securevault.SecureVaultException;
+import org.wso2.securevault.commons.MiscellaneousUtil;
+import org.wso2.securevault.keystore.IdentityKeyStoreWrapper;
+import org.wso2.securevault.keystore.TrustKeyStoreWrapper;
+import org.wso2.securevault.secret.SecretRepository;
+import org.wso2.securevault.secret.SecretRepositoryProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This class is responsible for initializing SecretRepositories which belongs to a particular provider.
+ * This is being called by the SecretManager by providing the secret configuration properties and the provider type
+ * and this will return a collection of initialized SecretRepositories.
+ *
+ * @see org.wso2.securevault.secret.SecretRepository
+ * @see org.wso2.securevault.secret.SecretManager
+ */
+public class VaultSecretRepositoryProvider implements SecretRepositoryProvider {
+
+    private static final Log log = LogFactory.getLog(VaultSecretRepositoryProvider.class);
+
+    // Property String for secretProviders.
+    private final static String PROP_SECRET_PROVIDERS = "secretProviders";
+
+    // Property String for repositories.
+    private final static String PROP_REPOSITORIES = "repositories";
+
+    // Property String for properties.
+    private final static String PROPERTIES = "properties";
+
+    // Dot String.
+    private final static String DOT = ".";
+
+    // Contains all initialized secret repositories under provider type vault.
+    private final Map<String, SecretRepository> vaultRepositoryMap = new HashMap<>();
+
+    /**
+     * @see org.wso2.securevault.secret.SecretRepositoryProvider
+     */
+    @Override
+    public SecretRepository getSecretRepository(IdentityKeyStoreWrapper identity, TrustKeyStoreWrapper trust) {
+
+        return null;
+    }
+
+    /**
+     * Returns a map containing initialized secret repositories corresponds to a give provider type.
+     *
+     * @param configurationProperties All the properties under secret configuration file.
+     * @param providerType            Type of the VaultSecretRepositoryProvider class.
+     * @return Initialized secret repository map.
+     * @throws SecureVaultException when creating the SecretRepository instances.
+     */
+    @Override
+    public Map<String, SecretRepository> initProvider(Properties configurationProperties, String providerType)
+            throws SecureVaultException {
+
+        // Get the list of repositories from the secret configurations.
+        StringBuilder repositoriesStringPropKey = new StringBuilder()
+                .append(PROP_SECRET_PROVIDERS)
+                .append(DOT)
+                .append(providerType)
+                .append(DOT)
+                .append(PROP_REPOSITORIES);
+
+        String repositoriesString = MiscellaneousUtil.getProperty(configurationProperties,
+                repositoriesStringPropKey.toString(), null);
+
+        if (MiscellaneousUtil.isValidPropertyValue(repositoriesString)) {
+            // Add the list of repositories to an array.
+            String[] repositories = repositoriesString.split(",");
+
+            for (String repo : repositories) {
+                // Get the property contains the fully qualified class name of the repository.
+                StringBuilder repositoryClassNamePropKey = new StringBuilder()
+                        .append(repositoriesStringPropKey.toString())
+                        .append(DOT)
+                        .append(repo);
+
+                String repositoryClassName = MiscellaneousUtil.getProperty(configurationProperties,
+                        repositoryClassNamePropKey.toString(), null);
+
+                if (MiscellaneousUtil.isValidPropertyValue(repositoryClassName)) {
+                    try {
+                        // Create a new instance of the class.
+                        Class repositoryClass = getClass().getClassLoader().loadClass(repositoryClassName.trim());
+                        Object repositoryImpl = repositoryClass.newInstance();
+
+                        if (repositoryImpl instanceof SecretRepository) {
+                            Properties repositoryProperties = filterConfigurations(configurationProperties, repo);
+                            ((SecretRepository) repositoryImpl).init(repositoryProperties, providerType);
+                            vaultRepositoryMap.put(repo, (SecretRepository) repositoryImpl);
+                        }
+                    } catch (Throwable e) {
+                        // RunTime Exceptions need to be handled.
+                        throw new SecureVaultException(
+                                "Error while initializing the secret repository " + repositoryClassName, e);
+                    }
+                }
+            }
+        }
+        return vaultRepositoryMap;
+    }
+
+    /**
+     * Return the properties for a provided repository.
+     *
+     * @param configProperties All the properties under secret configuration file.
+     * @param repository       Repository listed under the vault provider.
+     * @return Filtered properties.
+     */
+    private static Properties filterConfigurations(Properties configProperties, String repository) {
+
+        Properties filteredProps = new Properties();
+        StringBuilder propertyKeyPrefix = new StringBuilder()
+                .append(repository)
+                .append(DOT)
+                .append(PROPERTIES);
+
+        configProperties.forEach((propKey, propValue) -> {
+            if (propKey.toString().contains(propertyKeyPrefix)) {
+                filteredProps.put(propKey, propValue);
+            }
+        });
+        return filteredProps;
+    }
+}

--- a/src/test/java/org/wso2/securevault/secret/SecretManagerTest.java
+++ b/src/test/java/org/wso2/securevault/secret/SecretManagerTest.java
@@ -1,0 +1,136 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.securevault.secret;
+
+import org.powermock.reflect.Whitebox;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.securevault.SecureVaultException;
+
+import java.util.Properties;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test class for SecretManager.
+ */
+public class SecretManagerTest {
+
+    private SecretManager secretManager;
+
+    @BeforeClass
+    public void setUp() {
+
+        secretManager = SecretManager.getInstance();
+    }
+
+    @Test(description = "Test case for filterConfigurations() method.")
+    public void testFilterConfigurations() throws Exception {
+
+        Properties actual = Whitebox.invokeMethod(secretManager, "filterConfigurations", "secretProviders",
+                getConfigProperties());
+        Assert.assertEquals(12, actual.size());
+    }
+
+    @Test(description = "Test case for populateArray() method.")
+    public void testPopulateArray() throws Exception {
+
+        String[] actual = Whitebox.invokeMethod(secretManager, "populateArrayOfSecretProviders", "vault,hsm");
+        Assert.assertEquals(2, actual.length);
+    }
+
+    @Test(description = "Test case for resolveSecret() method.")
+    public void testResolveSecretNovel() throws Exception {
+
+        Whitebox.invokeMethod(secretManager, "readLegacyProviders", getConfigProperties());
+        Whitebox.invokeMethod(secretManager, "readNovelProviders", getConfigProperties());
+        String alias = secretManager.resolveSecret("vault:hashicorp:admin_password");
+        Assert.assertEquals("admin_password", alias);
+    }
+
+    @Test(description = "Test case for resolveSecret() method.")
+    public void testResolveSecretLegacy() throws Exception {
+
+        Whitebox.invokeMethod(secretManager, "readLegacyProviders", getConfigProperties());
+        Whitebox.invokeMethod(secretManager, "readNovelProviders", getConfigProperties());
+        String alias = secretManager.resolveSecret("admin_password");
+        Assert.assertEquals("admin_password", alias);
+    }
+
+    @Test(description = "Negative test case for resolveSecret() method.",
+            expectedExceptions = {SecureVaultException.class})
+    public void testResolveSecretNegative() throws Exception {
+
+        Whitebox.invokeMethod(secretManager, "readLegacyProviders", getConfigProperties());
+        Whitebox.invokeMethod(secretManager, "readNovelProviders", getConfigProperties());
+        when(secretManager.resolveSecret("vault:admin_password")).thenThrow(SecureVaultException.class);
+    }
+
+    private Properties getConfigProperties() {
+
+        Properties configProperties = new Properties();
+        configProperties.setProperty("keystore.identity.location",
+                "/home/User/wso2is-5.11.0/repository/resources/security/wso2carbon.jks");
+        configProperties.setProperty("keystore.identity.type", "JKS");
+        configProperties.setProperty("keystore.identity.store.password", "identity.store.password");
+        configProperties.setProperty("keystore.identity.key.password", "identity.key.password");
+        configProperties.setProperty("keystore.identity.store.secretProvider",
+                "org.wso2.carbon.securevault.DefaultSecretCallbackHandler");
+        configProperties.setProperty("keystore.identity.key.secretProvider",
+                "org.wso2.carbon.securevault.DefaultSecretCallbackHandler");
+        configProperties.setProperty("keystore.identity.alias", "wso2carbon");
+        configProperties.setProperty("carbon.secretProvider",
+                "org.wso2.securevault.secret.handler.SecretManagerSecretCallbackHandler");
+
+        configProperties.setProperty("secretRepositories", "file");
+        configProperties.setProperty("secretRepositories.file.provider",
+                "org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider");
+        configProperties
+                .setProperty("secretRepositories.file.location", "repository/conf/security/cipher-text.properties");
+
+        configProperties.setProperty("secretProviders", "vault");
+
+        configProperties.setProperty("secretProviders.vault.provider",
+                "org.wso2.securevault.provider.VaultSecretRepositoryProvider");
+
+        configProperties.setProperty("secretProviders.vault.repositories", "hashicorp,samplerepository1");
+
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp",
+                "org.wso2.carbon.securevault.hashicorp.repository.HashiCorpSecretRepository");
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1",
+                "org.wso2.carbon.securevault.repository.SampleRepository1");
+
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1.properties.1",
+                "samplerepository1prop1");
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1.properties.2",
+                "samplerepository1prop2");
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1.properties.3",
+                "samplerepository1prop3");
+
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.address",
+                "http://127.0.0.1:8200");
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.namespace", "wso2is");
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.path.prefix", "wso2is");
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.engineVersion", "2");
+
+        return configProperties;
+    }
+}

--- a/src/test/java/org/wso2/securevault/secret/repository/VaultSecretRepositoryProviderTest.java
+++ b/src/test/java/org/wso2/securevault/secret/repository/VaultSecretRepositoryProviderTest.java
@@ -1,0 +1,91 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.securevault.secret.repository;
+
+import org.powermock.reflect.Whitebox;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+/**
+ * Unit test class for VaultSecretRepositoryProvider.
+ */
+public class VaultSecretRepositoryProviderTest {
+
+    private VaultSecretRepositoryProvider vaultSecretRepositoryProvider;
+
+    @BeforeClass
+    public void setUp() {
+
+        vaultSecretRepositoryProvider = new VaultSecretRepositoryProvider();
+    }
+
+    @Test(description = "Test case for filterConfigurations() method.")
+    public void testFilterConfigurations() throws Exception {
+
+        Properties actual = Whitebox.invokeMethod(vaultSecretRepositoryProvider, "filterConfigurations",
+                getConfigProperties(), "hashicorp");
+        Assert.assertEquals(4, actual.size());
+    }
+
+    @Test(description = "Negative test case for filterConfigurations() method.")
+    public void testFilterConfigurationsNegative() throws Exception {
+
+        Properties actual = Whitebox.invokeMethod(vaultSecretRepositoryProvider, "filterConfigurations",
+                getConfigProperties(), "aws");
+        Assert.assertEquals(0, actual.size());
+    }
+
+    private Properties getConfigProperties() {
+
+        Properties configProperties = new Properties();
+        configProperties
+                .setProperty("secretRepositories.file.location", "repository/conf/security/cipher-text.properties");
+
+        configProperties.setProperty("secretProviders", "vault");
+
+        configProperties.setProperty("secretProviders.vault.provider",
+                "org.wso2.securevault.provider.VaultSecretRepositoryProvider");
+
+        configProperties.setProperty("secretProviders.vault.repositories", "hashicorp,samplerepository1");
+
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp",
+                "org.wso2.carbon.securevault.hashicorp.repository.HashiCorpSecretRepository");
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1",
+                "org.wso2.carbon.securevault.repository.SampleRepository1");
+
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1.properties.1",
+                "samplerepository1prop1");
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1.properties.2",
+                "samplerepository1prop2");
+        configProperties.setProperty("secretProviders.vault.repositories.samplerepository1.properties.3",
+                "samplerepository1prop3");
+
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.address",
+                "http://127.0.0.1:8200");
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.namespace", "wso2is");
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.path.prefix", "wso2is");
+        configProperties.setProperty("secretProviders.vault.repositories.hashicorp.properties.engineVersion", "2");
+
+        return configProperties;
+    }
+}


### PR DESCRIPTION
## Purpose
> The purpose of this Pull Request is to provide the Core Support for External Vault Support for Carbon Configurations.
> git issue - [Core support for external Vault Support for Carbon Configurations](https://github.com/wso2/product-is/issues/9149)

## Goals
> With this implementation, it will allow getting connected with external secure vaults. Meanwhile, the user will be able to use multiple vaults and this will work seamlessly with the existing implementations as well.

## Approach
> A special secret annotation will be used to define the provider type as well as repository type along with the alias of the secret.

           $secret { alias }  : $secret { provider: repository: alias }
>The SecretManager and the SecretManagerSecretCallbackHandler classes and the SecretRepository and the SecretRepositoryProvider Interfaces of the Carbon Securevault will be modified to build the required core support.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
>https://github.com/wso2/config-mapper/pull/19

## Test environment
> JDK version - 1.8
> Operating System - Ubuntu 18.04
 