### PR TITLE
Remove JDK version validation in ciphertool scripts

### DIFF
--- a/features/org.wso2.carbon.secvault.tools.feature/resources/bin/ciphertool.bat
+++ b/features/org.wso2.carbon.secvault.tools.feature/resources/bin/ciphertool.bat
@@ -51,19 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8
-goto jdk16
-
-:jdk16
-goto runTool
-
 rem ----------------- Execute The Requested Command ----------------------------
 :runTool
 cd %CARBON_HOME%

--- a/features/org.wso2.carbon.secvault.tools.feature/resources/bin/ciphertool.bat
+++ b/features/org.wso2.carbon.secvault.tools.feature/resources/bin/ciphertool.bat
@@ -58,7 +58,7 @@ echo JAVA_HOME environment variable is set to %JAVA_HOME%
 echo CARBON_HOME environment variable is set to %CARBON_HOME%
 
 set CMD_LINE_ARGS= -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%"
-java -cp "\bin\tools\*" -Dcarbon.home="%CARBON_HOME%" org.wso2.carbon.secvault.ciphertool.CipherToolInitializer %*
+java -cp "bin\tools\*" -Dcarbon.home="%CARBON_HOME%" org.wso2.carbon.secvault.ciphertool.CipherToolInitializer %*
 
 :end
 goto endlocal

--- a/features/org.wso2.carbon.secvault.tools.feature/resources/bin/ciphertool.sh
+++ b/features/org.wso2.carbon.secvault.tools.feature/resources/bin/ciphertool.sh
@@ -108,13 +108,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
-   exit 1
-fi
-
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
   JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`


### PR DESCRIPTION
## Purpose
Current scripts run the cipher tool only in JDK 8. This PR will remove that validation

Fixes https://github.com/wso2/product-ei/issues/5366