### PR TITLE
Add KeyStore Support to VaultSecretRepositoryProvider

### DIFF
--- a/src/main/java/org/wso2/securevault/SecurityConstants.java
+++ b/src/main/java/org/wso2/securevault/SecurityConstants.java
@@ -20,6 +20,7 @@ package org.wso2.securevault;
 
 public class SecurityConstants {
 
+    public static final String PROP_ENCRYPTION_ENABLED = "encryptionEnabled";
     public static final String PROP_USER_NAME = "username";
     public static final String PROP_PASSWORD = "password";
     public static final String PROP_PASSWORD_PROMPT = "passwordPrompt";

--- a/src/main/java/org/wso2/securevault/secret/SecretRepository.java
+++ b/src/main/java/org/wso2/securevault/secret/SecretRepository.java
@@ -18,6 +18,9 @@
  */
 package org.wso2.securevault.secret;
 
+import org.wso2.securevault.keystore.IdentityKeyStoreWrapper;
+import org.wso2.securevault.keystore.TrustKeyStoreWrapper;
+
 import java.util.Properties;
 
 /**
@@ -67,4 +70,12 @@ public interface SecretRepository {
      */
     SecretRepository getParent();
 
+    /**
+     * Sets the identity key store wrapper and trust key store wrapper.
+     *
+     * @param identityKeyStoreWrapper The identity key store wrapper to be set.
+     * @param trustKeyStoreWrapper The trust key store wrapper to be set.
+     */
+    default void setKeyStores(IdentityKeyStoreWrapper identityKeyStoreWrapper,
+                              TrustKeyStoreWrapper trustKeyStoreWrapper) {}
 }


### PR DESCRIPTION
## Purpose

Extensions have been implemented to use Azure Key Vault or AWS Secrets Manager as external secret repositories with Carbon Secure Vault. These two extensions also support combining the external secret repository with Carbon Secure Vault's file-based internal secret repository for additional security. However, this combined use is only possible when Carbon Secure Vault is configured using the legacy configurations and not with the novel configurations.

This is because the novel configurations do not support the initialization of the internal KeyStore for use with Carbon Secure Vault at the moment. The purpose of this PR is to allow novel configurations to support KeyStore initialization even with the novel configuration.

Resolves https://github.com/wso2/product-is/issues/14000.

## Goals

Allow vaults provided by the `VaultSecretRepositoryProvider` to access the KeStore wrappers.

## Approach

Allow the initialization of the internal KeyStore and pass the KeyStore wrappers to the external secret repository as with the legacy configurations based on a configuration.

The Carbon Secure Vault secret manager would check for configuration properties ending with the suffix `encryptionEnabled` and initialize the KeyStore if the value is set to true.

For example, if the Azure Secret Repository has encryption enabled as shown below, the secret manager would pick up on this and initialize the KeyStore.

```
secretProviders.vault.repositories.azure.properties.encryptionEnabled=true
```

Following this, the KeyStore wrappers would then be passed from the secret manager to the external secret repository that had enabled encryption via the `VaultSecretRepositoryProvider`.

## Release note
KeyStore support for `VaultSecretRepositoryProvider`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
- https://github.com/wso2-extensions/carbon-securevault-azure/pull/1

## Test environment
> JDK 1.8
> Windows