### PR TITLE
Change access modifier of extractProtectedTokens method and ProtectedToken class to be public

### DIFF
--- a/src/main/java/org/wso2/securevault/commons/MiscellaneousUtil.java
+++ b/src/main/java/org/wso2/securevault/commons/MiscellaneousUtil.java
@@ -297,7 +297,7 @@ public class MiscellaneousUtil {
         return true;
     }
 
-    static List<ProtectedToken> extractProtectedTokens(String text) {
+    public static List<ProtectedToken> extractProtectedTokens(String text) {
 
         List<ProtectedToken> tokenList = new ArrayList<>();
 
@@ -318,7 +318,7 @@ public class MiscellaneousUtil {
         return tokenList;
     }
 
-    static class ProtectedToken {
+    public static class ProtectedToken {
 
         private int startIndex;
         private int endIndex;
@@ -331,17 +331,17 @@ public class MiscellaneousUtil {
             this.value = value;
         }
 
-        int getStartIndex() {
+        public int getStartIndex() {
 
             return startIndex;
         }
 
-        String getValue() {
+        public String getValue() {
 
             return value;
         }
 
-        int getEndIndex() {
+        public int getEndIndex() {
 
             return endIndex;
         }


### PR DESCRIPTION
## Purpose
Currently carbon-kernel uses `getProtectedToken()` method to retrieve secret alias of a given OMElement. This OMElement can only contain a whole secret alias with the syntax `$secret{key}`. We require to add capability to resolve embedded and multiple secrets in a given string. For that, we can reuse `extractProtectedTokens()` method of `MiscellaneousUtil` class. However this is declared as package-private with default access modifier.

This PR intend to make `extractProtectedTokens()` method and related `ProtectedToken` nested class public.

### Related issue
- https://github.com/wso2/product-is/issues/14109

### Related PR
- https://github.com/wso2/carbon-kernel/pull/3357
