### PR TITLE
Bump snakeyaml 2.2 → 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <slf4j.api.version>1.7.36</slf4j.api.version>
         <equinox.osgi.version>3.11.0.v20160603-1336</equinox.osgi.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
-        <org.snakeyaml.version>2.2</org.snakeyaml.version>
+        <org.snakeyaml.version>2.6</org.snakeyaml.version>
         <testng.version>6.9.4</testng.version>
         <easymock.version>3.4</easymock.version>
         <powermock.api.easymock.version>1.6.5</powermock.api.easymock.version>


### PR DESCRIPTION
## Summary

- Bumps `org.snakeyaml.version` from `2.2` to `2.6` in the root `pom.xml`
- The existing OSGi import range `[2.0.0,3.0.0)` already covers 2.6 — no other changes needed
- Motivated by CVE mitigations addressed in snakeyaml 2.4+ (part of the SI 4.3.2 release dependency hygiene pass)

## Test plan

- [x] `mvn clean install` passes locally with Java 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to latest stable version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->